### PR TITLE
feat: #494 update rp-adapter && edge-agent

### DIFF
--- a/cmd/rp-rest/static/bankaccount.html
+++ b/cmd/rp-rest/static/bankaccount.html
@@ -203,7 +203,7 @@ SPDX-License-Identifier: Apache-2.0
         console.log("Receiving presentation from wallet")
         axios({
             method: "GET",
-            url: "/oauth2/request?scope=DrivingLicense"
+            url: "/oauth2/request?scope=driver_license:local"
         }).then(
             resp => {window.location.href = resp.data.request},
             err => console.error(err)

--- a/cmd/rp-rest/static/index.html
+++ b/cmd/rp-rest/static/index.html
@@ -415,7 +415,7 @@ SPDX-License-Identifier: Apache-2.0
     async function getCreditCardStatement() {
         axios({
             method: "GET",
-            url: "/oauth2/request?scope=CreditCardStatement"
+            url: "/oauth2/request?scope=credit_card_stmt:remote"
         }).then(
             resp => {window.location.href = resp.data.request},
             err => console.error(err)

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -13,7 +13,7 @@ CONSENT_LOGIN_SERVER_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/login-co
 
 # Edge agent
 USER_AGENT_WASM_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/user-agent-wasm
-USER_AGENT_WASM_IMAGE_TAG=0.1.4-snapshot-ea9b227
+USER_AGENT_WASM_IMAGE_TAG=0.1.4-snapshot-8c7ec43
 WALLET_ROUTER_URL=https://router.trustbloc.local
 
 # Edge service
@@ -88,7 +88,7 @@ ISSUER_ADAPTER_DIDCOMM_PORT=10062
 
 # RP Adapter
 RP_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/rp-adapter-rest
-RP_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-63be9cf
+RP_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-0f3b643
 RP_ADAPTER_HOST=0.0.0.0
 RP_ADAPTER_PORT=10161
 RP_ADAPTER_DIDCOMM_PORT=10162

--- a/test/bdd/fixtures/demo/adapter-config/rp/presentationdefinitions.json
+++ b/test/bdd/fixtures/demo/adapter-config/rp/presentationdefinitions.json
@@ -1,16 +1,60 @@
 {
-  "CreditCardStatement": {
+  "credit_card_stmt:remote": {
     "schema": {
-      "uri": "https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld",
+      "uri": ["https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld"],
       "name": "Bank Account Information",
-      "purpose": "We need your bank and account information."
+      "purpose": "We need your consent to access your bank and account information."
+    },
+    "constraints": {
+      "fields": [
+        {
+          "path": ["$.credentialSubject.scope[*].schema.uri"],
+          "filter": {
+            "const": "https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld"
+          }
+        }
+      ]
     }
   },
-  "DrivingLicense": {
+  "driver_license:local": {
     "schema": {
-      "uri": "https://trustbloc.github.io/context/vc/examples/mdl-v1.jsonld",
-      "name": "Driving License Information",
-      "purpose": "We need your driving License information."
+      "uri": ["https://trustbloc.github.io/context/vc/examples/mdl-v1.jsonld"],
+      "name": "Driver's license.",
+      "purpose": "Verify your identity."
+    }
+  },
+  "driver_license_evidence:remote": {
+    "schema": {
+      "uri": ["https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld"],
+      "name": "Authorization to verify your driver's license.",
+      "purpose": "We need your consent to verify issuance of your driver's license."
+    },
+    "constraints": {
+      "fields": [
+        {
+          "path": ["$.credentialSubject.scope[*].schema.uri"],
+          "filter": {
+            "const": "https://trustbloc.github.io/context/vc/examples/driver-license-evidence-v1.jsonld"
+          }
+        }
+      ]
+    }
+  },
+  "credit_score:remote": {
+    "schema": {
+      "uri": ["https://trustbloc.github.io/context/vc/authorization-credential-v1.jsonld"],
+      "name": "Authorization to access your credit score.",
+      "purpose": "Determine eligibility for the service."
+    },
+    "constraints": {
+      "fields": [
+        {
+          "path": ["$.credentialSubject.scope[*].schema.uri"],
+          "filter": {
+            "const": "https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"
+          }
+        }
+      ]
     }
   }
 }

--- a/test/bdd/fixtures/scripts/rp-rest_start.sh
+++ b/test/bdd/fixtures/scripts/rp-rest_start.sh
@@ -19,7 +19,7 @@ registerRPTenant() {
         response=$(curl -k -o - -s -w "RESPONSE_CODE=%{response_code}" \
         --header "Content-Type: application/json" \
         --request POST \
-        --data '{"label": "rp.trustbloc.local", "callback": "'$callbackURL'", "scopes": ["CreditCardStatement","DrivingLicense"]}' \
+        --data '{"label": "rp.trustbloc.local", "callback": "'$callbackURL'", "scopes": ["credit_card_stmt:remote","driver_license:local"]}' \
         $rpAdapterURL)
 
         code=${response//*RESPONSE_CODE=/}


### PR DESCRIPTION
closes #494

* edge-agent:
  * can now select issuer manifest credential from a schema uri inside constraints: trustbloc/edge-agent#295
  * credential storage (plaintext for now) trustbloc/edge-agent#285
  * revert CHAPI mediator customizations trustbloc/edge-agent#302
  * fix invalid json paths in presentation submission
  trustbloc/edge-agent#301
* rp-adapter:
  * handle local and remote credentials trustbloc/edge-adapter#257
  * map credentialSubject to RP object `verified_claims`
  trustbloc/edge-adapter#161
  * fix error parsing VCs in response trustbloc/edge-adapter#270
  * fix panic on startup when GOVERNANCE_VCS URL is not provided
  trustbloc/edge-adapter#266
  * fix presentation-exchange schema uri should be an array
  trustbloc/edge-adapter#256

Signed-off-by: George Aristy <george.aristy@securekey.com>