### PR TITLE
chore: update DIDComm components

### DIFF
--- a/cmd/acrp-rest/go.sum
+++ b/cmd/acrp-rest/go.sum
@@ -546,6 +546,8 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210122151214-1a54003224a0/g
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384 h1:A3LUAJFT/1InupOXdUVzXMqr1n2vR9mfH4xUdglVHrw=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201119153638-fc5d5e680587/go.mod h1:/ySOxjKsxV+rnorkp7VZHw/1/OQtxRYlgibhcQVWw/E=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
@@ -553,6 +555,8 @@ github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-2021
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5/go.mod h1:6h4vLybbbz82KKsU5Qi15+SOT76U6jbd1//QL5ywQIM=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/cmd/issuer-rest/go.sum
+++ b/cmd/issuer-rest/go.sum
@@ -546,6 +546,8 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384 h1:A3LUAJFT/1InupOXdUVzXMqr1n2vR9mfH4xUdglVHrw=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201119153638-fc5d5e680587/go.mod h1:/ySOxjKsxV+rnorkp7VZHw/1/OQtxRYlgibhcQVWw/E=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
@@ -553,6 +555,8 @@ github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-2021
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5/go.mod h1:6h4vLybbbz82KKsU5Qi15+SOT76U6jbd1//QL5ywQIM=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/cmd/rp-rest/go.sum
+++ b/cmd/rp-rest/go.sum
@@ -541,11 +541,15 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384 h1:A3LUAJFT/1InupOXdUVzXMqr1n2vR9mfH4xUdglVHrw=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201119153638-fc5d5e680587/go.mod h1:/ySOxjKsxV+rnorkp7VZHw/1/OQtxRYlgibhcQVWw/E=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c/go.mod h1:QbfFi1eodurSG8dvhPDWWLrYmNJBrbxeviUnQ/Y1lyo=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5/go.mod h1:6h4vLybbbz82KKsU5Qi15+SOT76U6jbd1//QL5ywQIM=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384
+	github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266 h
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210127113808-f60b9683e266/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384 h1:A3LUAJFT/1InupOXdUVzXMqr1n2vR9mfH4xUdglVHrw=
 github.com/hyperledger/aries-framework-go v0.1.6-0.20210203215323-783f4d353384/go.mod h1:CB1aCGsuCC/U+mJ43aU5Nx7s6iCYOVquO7kCUn8tVhY=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9 h1:UHllztcNHODHT4MaL7rv9cAAFGdok6B3a/G69dYMw80=
+github.com/hyperledger/aries-framework-go v0.1.6-0.20210210013602-d14c77b2e8a9/go.mod h1:jWpvVjYk1wETWfVJBII71ta6LusGKbzOkha8TOxeBRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20201119153638-fc5d5e680587/go.mod h1:M7/MF6JD45J4CfhiHuO/CSt9ryzQR+ApV3IOAn2HKzo=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20201119153638-fc5d5e680587/go.mod h1:/ySOxjKsxV+rnorkp7VZHw/1/OQtxRYlgibhcQVWw/E=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-20210121210840-ee9984a4579c h1:4KLf7FrV0UCxK61nSEy+apL1BKJYK/SXiZYl4+MW2ps=
@@ -555,6 +557,8 @@ github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v0.0.0-2021
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37 h1:25yXEZ7X6OT7BfE4HSs5+JVQGv+5P2UdNVvGIOPMpBs=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/trustbloc v0.0.0-20210125133828-10c25f5d6d37/go.mod h1:K+M5o2GqeLx3POTxg4ceNZiGq5PYK1NA2HsZ88DWNFU=
 github.com/hyperledger/aries-framework-go-ext/test/component/storage v0.0.0-20201020105420-c85a221b09b5/go.mod h1:6h4vLybbbz82KKsU5Qi15+SOT76U6jbd1//QL5ywQIM=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325 h1:CmZ1Z8SxVbNxZPKih/eOY52CsYTuE1qweIMrGS/Zy6E=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210208194322-89066ddae325/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21 h1:qSa8O/Xktnwh3zOdLYL3LFS3ARQ0K4m8JUdC0GJz3bU=
 github.com/igor-pavlenko/httpsignatures-go v0.0.21/go.mod h1:3LVsCi3evlfQSNDKMTg3uElxEP8SjK3/Q5N9I8GU9W0=

--- a/pkg/restapi/issuer/operation/operations.go
+++ b/pkg/restapi/issuer/operation/operations.go
@@ -1221,7 +1221,7 @@ func (c *Operation) getUserData(tk *oauth2.Token, searchQuery, scope string) (st
 	return user.UserID, respBytes, nil
 }
 
-// nolint: interfacer
+// nolint:interfacer
 func sendHTTPRequest(req *http.Request, client *http.Client, status int, httpToken string) ([]byte, error) {
 	if httpToken != "" {
 		req.Header.Add("Authorization", "Bearer "+httpToken)

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -14,9 +14,9 @@ CONSENT_LOGIN_SERVER_IMAGE=ghcr.io/trustbloc/sandbox-login-consent-server
 
 # Edge agent
 USER_AGENT_IMAGE=ghcr.io/trustbloc-cicd/wallet-web
-USER_AGENT_IMAGE_TAG=0.1.6-snapshot-382de67
+USER_AGENT_IMAGE_TAG=0.1.6-snapshot-c37dd2e
 USER_AGENT_SUPPORT_IMAGE=ghcr.io/trustbloc-cicd/wallet-server
-USER_AGENT_SUPPORT_IMAGE_tag=0.1.6-snapshot-382de67
+USER_AGENT_SUPPORT_IMAGE_tag=0.1.6-snapshot-c37dd2e
 WALLET_ROUTER_URL=https://router.trustbloc.local:9084
 SUPPORT_BLINDED_ROUTING=true
 
@@ -79,7 +79,7 @@ HTTP_RESOLVER=trustbloc@https://did-resolver.trustbloc.local/1.0/identifiers,v1@
 # ------------------- DIDComm -------------------
 # Aries Router configurations
 HUB_ROUTER_IMAGE=ghcr.io/trustbloc-cicd/hub-router
-HUB_ROUTER_IMAGE_TAG=0.1.6-snapshot-a1c99d0
+HUB_ROUTER_IMAGE_TAG=0.1.6-snapshot-297f289
 DIDCOMM_ROUTER_HOST=0.0.0.0
 DIDCOMM_ROUTER_HTTP_INBOUND_PORT=9081
 DIDCOMM_ROUTER_WS_INBOUND_PORT=9082
@@ -87,14 +87,14 @@ DIDCOMM_ROUTER_API_PORT=9084
 
 # Issuer adapter
 ISSUER_ADAPTER_REST_IMAGE=ghcr.io/trustbloc-cicd/issuer-adapter
-ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.6-snapshot-ab87409
+ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.6-snapshot-5caec42
 ISSUER_ADAPTER_HOST=0.0.0.0
 ISSUER_ADAPTER_PORT=10061
 ISSUER_ADAPTER_DIDCOMM_PORT=10062
 
 # RP Adapter
 RP_ADAPTER_REST_IMAGE=ghcr.io/trustbloc-cicd/rp-adapter
-RP_ADAPTER_REST_IMAGE_TAG=0.1.6-snapshot-ab87409
+RP_ADAPTER_REST_IMAGE_TAG=0.1.6-snapshot-5caec42
 RP_ADAPTER_HOST=0.0.0.0
 RP_ADAPTER_PORT=10161
 RP_ADAPTER_DIDCOMM_PORT=10162


### PR DESCRIPTION
aries-framework-go now supports Aries RFC0360: hyperledger/aries-framework-go#2526

Signed-off-by: George Aristy <george.aristy@securekey.com>