### PR TITLE
refactor: ACRP - send nationalid in a plain map rather than vc

### DIFF
--- a/docs/demo/build.md
+++ b/docs/demo/build.md
@@ -9,6 +9,7 @@
 - Docker
 - Docker-Compose
 - Make
+- [jq](https://stedolan.github.io/jq/)
 
 # Setup CA and hostnames
 Run trustbloc-local-setup(`make trustbloc-local-setup`) this target will generate:


### PR DESCRIPTION
Currently, CSH does byte-by-byte comparison. As a work around, nationalID is saved in plain json for now.

part of #811 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>