### PR TITLE
chore: confidential-storage-hub - support did:trustbloc

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -117,12 +117,12 @@ HYDRA_IMAGE_TAG=v1.3.2-alpine
 
 # Vault Server
 VAULT_SERVER_IMAGE=ghcr.io/trustbloc-cicd/vault-server
-VAULT_SERVER_IMAGE_TAG=0.1.6-snapshot-054a71f
+VAULT_SERVER_IMAGE_TAG=0.1.6-snapshot-391c1d3
 
 # Comparator
 COMPARATOR_REST_IMAGE=ghcr.io/trustbloc-cicd/comparator-server
-COMPARATOR_REST_IMAGE_TAG=0.1.6-snapshot-054a71f
+COMPARATOR_REST_IMAGE_TAG=0.1.6-snapshot-391c1d3
 
 # CSH
 CSH_IMAGE=ghcr.io/trustbloc-cicd/hub-confidential-storage
-CSH_IMAGE_TAG=0.1.6-snapshot-054a71f
+CSH_IMAGE_TAG=0.1.6-snapshot-391c1d3

--- a/test/bdd/fixtures/demo/docker-compose-csh.yml
+++ b/test/bdd/fixtures/demo/docker-compose-csh.yml
@@ -18,6 +18,8 @@ services:
         - DATABASE_URL=couchdb://${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@shared.couchdb:5984
         - DATABASE_PREFIX=confidentialstoragehub
         - VIRTUAL_HOST=csh.trustbloc.local
+        - TRUSTBLOC_DID_DOMAIN=testnet.trustbloc.local
+        - IDENTITY_DID_METHOD=trustbloc
     ports:
       - 8063:8063
     entrypoint: ""


### PR DESCRIPTION
Feature:

* ConfidentialStorageHub now supports using `did:trustbloc` for its identity: https://github.com/trustbloc/edge-service/pull/657

Tested with the [Anonymous Comparator and Extractor (ACE) Demo Playground](https://github.com/trustbloc/sandbox/blob/main/docs/demo/sandbox_ace_playground.md) flow.

Signed-off-by: George Aristy <george.aristy@securekey.com>