### PR TITLE
feat: issuer adapter oidc integration

### DIFF
--- a/cmd/issuer-rest/static/js/action.js
+++ b/cmd/issuer-rest/static/js/action.js
@@ -81,7 +81,6 @@ $(document).ready(function () {
 
     $('#creditCard').on('click', function() {
         if (!$(this).data('clicked')) {
-            $('#demoType').val("DIDComm");
             $('#didCommScope').val("CreditCardStatement");
             $('#adapterProfile').val("tb-cc-issuer");
             $(this).data('clicked', true);
@@ -91,7 +90,6 @@ $(document).ready(function () {
 
     $('#drivingLicense').on('click', function() {
         if (!$(this).data('clicked')) {
-            $('#demoType').val("DIDComm");
             $('#didCommScope').val("mDL");
             $('#adapterProfile').val("tb-dl-issuer");
             $('#assuranceScope').val("mdlevidences");
@@ -102,7 +100,6 @@ $(document).ready(function () {
 
     $('#uploadDrivingLicense').on('click', function() {
         if (!$(this).data('clicked')) {
-            $('#demoType').val("DIDComm");
             $('#didCommScope').val("mDL");
             $('#adapterProfile').val("tb-dl-issuer");
             $('#assuranceScope').val("mdlevidences");
@@ -112,7 +109,6 @@ $(document).ready(function () {
 
     $('#creditScore').on('click', function() {
         if (!$(this).data('clicked')) {
-            $('#demoType').val("DIDComm");
             $('#didCommScope').val("CreditScore");
             $('#adapterProfile').val("tb-cr-issuer");
             $(this).data('clicked', true);
@@ -168,21 +164,14 @@ $(document).ready(function () {
     });
 
     $('#didCommDemo').submit(function () {
-
-        if($('#creditCard').data('clicked'))
-        {
-            $('#didCommDemo').attr('action', '/login?');
-
-        } else if ($("#drivingLicense").data('clicked'))
-        {
-            $('#didCommDemo').attr('action', '/login?');
-
-        } else if ($("#creditScore").data('clicked'))
-        {
-            $('#didCommDemo').attr('action', '/login?');
-        } else if ($("#uploadDrivingLicense").data('clicked'))
-        {
-            $('#didCommDemo').attr('action', '/login?');
+        if($('#creditCard').data('clicked')) {
+            $('#didCommDemo').attr('action', '/didcomm/init?');
+        } else if ($("#drivingLicense").data('clicked')) {
+            $('#didCommDemo').attr('action', '/didcomm/init?');
+        } else if ($("#creditScore").data('clicked')) {
+            $('#didCommDemo').attr('action', '/didcomm/init?');
+        } else if ($("#uploadDrivingLicense").data('clicked')) {
+            $('#didCommDemo').attr('action', '/didcomm/init?');
         }
     });
 });

--- a/cmd/login-consent-server/templates/bankconsent.html
+++ b/cmd/login-consent-server/templates/bankconsent.html
@@ -86,12 +86,12 @@ SPDX-License-Identifier: Apache-2.0
                                 <div class="text-center py-2"></div>
                             </div>
                             <form action="" method="POST">
-                                <p class="text-black text-lg">I agree with the above terms and conditions {{.User}} , application <strong>{{.ClientID}}</strong> can access the resource</p>
+                                <p class="text-black text-lg">I agree with the above terms and conditions {{.User}} , application <strong>{{.ClientName}}</strong> can access the resource</p>
                                 <br>
                                 {{range $element := .Scope}}
                                 <label class="md:w-2/3 block text-gray-500 font-bold">
-                                    <input {{if eq $element "openid"}} type="hidden"{{end}} class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
-                                    <span {{if eq $element "openid"}} hidden{{end}} class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
+                                    <input {{if eq $element "openid" "offline_access"}} type="hidden"{{end}} class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
+                                    <span {{if eq $element "openid" "offline_access"}} hidden{{end}} class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
                                 </label>
                                 {{end}}
                                 <br>

--- a/cmd/login-consent-server/templates/consent.html
+++ b/cmd/login-consent-server/templates/consent.html
@@ -100,11 +100,11 @@ SPDX-License-Identifier: Apache-2.0
                         <div class="px-6 py-4 bg-gray-100 justify-center">
                             <p class="font-bold text-xl text-black mb-2">An application requests access to your data</p>
                             <form action="" method="POST">
-                                <p class="text-gray-700 text-base">Hi {{.User}}, application <strong>{{.ClientID}}</strong> wants access resources on your behalf:</p>
+                                <p class="text-gray-700 text-base">Hi {{.User}}, application <strong>{{.ClientName}}</strong> wants to access resources on your behalf:</p>
                                 {{range $element := .Scope}}
                                 <label class="md:w-2/3 block text-gray-500 font-bold">
-                                    <input class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
-                                    <span class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
+                                    <input {{if eq $element "openid" "offline_access"}}type="hidden"{{end}} class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
+                                    <span {{if eq $element "openid" "offline_access"}}hidden{{end}} class="text-lg text-black" id="{{$element}}-name" for="{{$element}}">{{$element}}</span>
                                 </label>
                                 {{end}}
                                 <br>
@@ -190,9 +190,9 @@ SPDX-License-Identifier: Apache-2.0
         return scopes[name];
     }
     $(document).ready(function () {
-        var name = document.getElementById("scopeName").innerText
-        var scopeName =  getScopeName(name);
-        document.getElementById("scopeName").innerText = scopeName;
+        {{range $element := .Scope}}
+        document.getElementById("{{$element}}-name").innerText = getScopeName("{{$element}}");
+        {{end}}
     });
 </script>
 </body>

--- a/cmd/login-consent-server/templates/uploadCredConsent.html
+++ b/cmd/login-consent-server/templates/uploadCredConsent.html
@@ -100,11 +100,11 @@ SPDX-License-Identifier: Apache-2.0
                         <div class="px-6 py-4 bg-gray-100 justify-center">
                             <p class="font-bold text-xl text-black mb-2">An application requests access to your data</p>
                             <form action="" method="POST">
-                                <p class="text-gray-700 text-base"><strong>{{.ClientID}}</strong> wants access resources on your behalf:</p>
+                                <p class="text-gray-700 text-base"><strong>{{.ClientName}}</strong> wants access resources on your behalf:</p>
                                 {{range $element := .Scope}}
                                 <label class="md:w-2/3 block text-gray-500 font-bold">
-                                    <input class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
-                                    <span class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
+                                    <input {{if eq $element "openid" "offline_access"}}type="hidden"{{end}} class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
+                                    <span {{if eq $element "openid" "offline_access"}}hidden{{end}} class="text-lg text-black" id="{{$element}}-name" for="{{$element}}">{{$element}}</span>
                                     {{end}}
                                 </label>
                                 <br>
@@ -190,9 +190,9 @@ SPDX-License-Identifier: Apache-2.0
         return scopes[name];
     }
     $(document).ready(function () {
-        var name = document.getElementById("scopeName").innerText
-        var scopeName =  getScopeName(name);
-        document.getElementById("scopeName").innerText = scopeName;
+        {{range $element := .Scope}}
+        document.getElementById("{{$element}}-name").innerText = getScopeName("{{$element}}");
+        {{end}}
     });
 </script>
 </body>

--- a/pkg/restapi/issuer/controller_test.go
+++ b/pkg/restapi/issuer/controller_test.go
@@ -39,5 +39,5 @@ func TestController_GetOperations(t *testing.T) {
 	require.NotNil(t, controller)
 
 	ops := controller.GetOperations()
-	require.Equal(t, 14, len(ops))
+	require.Equal(t, 16, len(ops))
 }

--- a/pkg/restapi/issuer/operation/support_test.go
+++ b/pkg/restapi/issuer/operation/support_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/trustbloc/sandbox/pkg/token"
+)
+
+func handleRequest(handler Handler, headers map[string]string, path string, addCookie bool) (*bytes.Buffer, int, error) { //nolint:lll
+	var cookie *http.Cookie
+
+	if addCookie {
+		cookie = &http.Cookie{Name: vcsProfileCookie, Value: "vc-issuer-1"}
+	}
+
+	return handleRequestWithCookie(handler, headers, path, cookie)
+}
+
+func handleRequestWithCookie(handler Handler, headers map[string]string, path string, cookie *http.Cookie) (*bytes.Buffer, int, error) { //nolint:lll
+	if cookie == nil {
+		return handleRequestWithCookies(handler, headers, path, nil)
+	}
+
+	return handleRequestWithCookies(handler, headers, path, []*http.Cookie{cookie})
+}
+
+func handleRequestWithCookies(handler Handler, headers map[string]string, path string, cookies []*http.Cookie) (*bytes.Buffer, int, error) { //nolint:lll,unparam
+	req, err := http.NewRequest(handler.Method(), path, bytes.NewBuffer([]byte("")))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	router := mux.NewRouter()
+
+	router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
+
+	// create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	return rr.Body, rr.Code, nil
+}
+
+func getHandlerWithOps(t *testing.T, lookup string, cfg *Config) (*Operation, Handler) {
+	svc, err := New(cfg)
+	require.NotNil(t, svc)
+	require.NoError(t, err)
+
+	return svc, handlerLookup(t, svc, lookup)
+}
+
+func getHandlerWithConfig(t *testing.T, lookup string, cfg *Config) Handler {
+	svc, err := New(cfg)
+	require.NotNil(t, svc)
+	require.NoError(t, err)
+
+	return handlerLookup(t, svc, lookup)
+}
+
+func handlerLookup(t *testing.T, op *Operation, lookup string) Handler {
+	handlers := op.GetRESTHandlers()
+	require.NotEmpty(t, handlers)
+
+	for _, h := range handlers {
+		if h.Path() == lookup {
+			return h
+		}
+	}
+
+	require.Fail(t, "unable to find handler")
+
+	return nil
+}
+
+func serveHTTP(t *testing.T, handler http.HandlerFunc, method, path string, req []byte) *httptest.ResponseRecorder { // nolint: unparam,lll
+	httpReq, err := http.NewRequest(
+		method,
+		path,
+		bytes.NewBuffer(req),
+	)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, httpReq)
+
+	return rr
+}
+
+type mockTokenIssuer struct {
+	err error
+}
+
+func (m *mockTokenIssuer) AuthCodeURL(w http.ResponseWriter) string {
+	return "url"
+}
+
+func (m *mockTokenIssuer) Exchange(r *http.Request) (*oauth2.Token, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &oauth2.Token{}, nil
+}
+
+func (m *mockTokenIssuer) Client(t *oauth2.Token) *http.Client {
+	return http.DefaultClient
+}
+
+type mockTokenResolver struct {
+	info token.Introspection
+	err  error
+}
+
+func (r *mockTokenResolver) Resolve(string) (*token.Introspection, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return &r.info, nil
+}
+
+type mockOIDCClient struct {
+	createOIDCRequest     string
+	createOIDCRequestErr  error
+	handleOIDCCallbackErr error
+}
+
+func (m *mockOIDCClient) CreateOIDCRequest(state, scope string) (string, error) {
+	return m.createOIDCRequest, m.createOIDCRequestErr
+}
+
+func (m *mockOIDCClient) HandleOIDCCallback(reqContext context.Context, code string) ([]byte, error) {
+	return nil, m.handleOIDCCallbackErr
+}
+
+func newCreateOIDCHTTPRequest(scope string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/oauth2/request?scope=%s", scope), nil)
+}
+
+func newOIDCCallback(state, code string) *http.Request {
+	return httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://example.com/oauth2/callback?state=%s&code=%s", state, code), nil)
+}

--- a/test/bdd/fixtures/demo/docker-compose-adapter.yml
+++ b/test/bdd/fixtures/demo/docker-compose-adapter.yml
@@ -28,6 +28,7 @@ services:
       - ADAPTER_REST_GOVERNANCE_VCS_URL=https://governance-vcs.trustbloc.local
       - ADAPTER_REST_REQUEST_TOKENS=vcs_governance=vcs_governance_rw_token
       - OIDC_STORE_KEY=/etc/store-keys/oidc-enc.key
+      - ADAPTER_REST_EXTERNAL_URL=https://issuer-adapter.trustbloc.local:${ISSUER_ADAPTER_PORT}
     ports:
       - ${ISSUER_ADAPTER_PORT}:${ISSUER_ADAPTER_PORT}
       - ${ISSUER_ADAPTER_DIDCOMM_PORT}:${ISSUER_ADAPTER_DIDCOMM_PORT}

--- a/test/bdd/fixtures/demo/docker-compose-auth.yml
+++ b/test/bdd/fixtures/demo/docker-compose-auth.yml
@@ -95,6 +95,8 @@ services:
       - VIRTUAL_HOST=hydra.trustbloc.local
       - VIRTUAL_PORT=4444
       - VIRTUAL_PROTO=https
+      - OIDC_DYNAMIC_CLIENT_REGISTRATION_DEFAULT_SCOPE=openid,offline_access
+      - WEBFINGER_OIDC_DISCOVERY_CLIENT_REGISTRATION_URL=https://hydra.trustbloc.local:4445/clients/
     restart: unless-stopped
     volumes:
       - ../scripts/hydra/hydra_configure.sh:/tmp/hydra_configure.sh

--- a/test/bdd/fixtures/scripts/didcomm/issuer_adapter_configure.sh
+++ b/test/bdd/fixtures/scripts/didcomm/issuer_adapter_configure.sh
@@ -15,7 +15,7 @@ until [ $n -ge $maxAttempts ]
 do
    responseCreatedTime=$(curl -k --header "Content-Type: application/json" \
    --request POST \
-   --data '{"id":"tb-cc-issuer", "name":"TrustBloc - Credit Card Data Issuer", "url":"https://issuer.trustbloc.local/didcomm", "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld"]}' \
+   --data '{"id":"tb-cc-issuer", "name":"TrustBloc - Credit Card Data Issuer", "url":"https://issuer.trustbloc.local/didcomm", "oidcProvider":"https://hydra.trustbloc.local/", "scopes":["CreditCardStatement"],  "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld"]}' \
    --insecure https://issuer.adapter.rest.example.com:10061/profile | jq -r '.createdAt' 2>/dev/null)
    echo "'created' field from profile tb-cc-issuer response is: $responseCreatedTime"
 
@@ -40,7 +40,7 @@ until [ $n -ge $maxAttempts ]
 do
    responseCreatedTime=$(curl -k --header "Content-Type: application/json" \
    --request POST \
-   --data '{"id":"tb-cr-issuer", "name":"TrustBloc - Credit Report Issuer", "url":"https://issuer.trustbloc.local/didcomm", "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"], "requiresBlindedRoute": true}' \
+   --data '{"id":"tb-cr-issuer", "name":"TrustBloc - Credit Report Issuer", "url":"https://issuer.trustbloc.local/didcomm", "oidcProvider":"https://hydra.trustbloc.local/", "scopes":["CreditScore"], "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"], "requiresBlindedRoute": true}' \
    --insecure https://issuer.adapter.rest.example.com:10061/profile | jq -r '.createdAt' 2>/dev/null)
    echo "'created' field from profile tb-cr-issuer response is: $responseCreatedTime"
 
@@ -64,7 +64,7 @@ until [ $n -ge $maxAttempts ]
 do
    responseCreatedTime=$(curl -k --header "Content-Type: application/json" \
    --request POST \
-   --data '{"id":"tb-dl-issuer", "name":"TrustBloc - Driving License + Assurance Issuer", "url":"https://issuer.trustbloc.local/didcomm", "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/driver-license-evidence-v1.jsonld"], "supportsAssuranceCredential" : true, "requiresBlindedRoute": true}' \
+   --data '{"id":"tb-dl-issuer", "name":"TrustBloc - Driving License + Assurance Issuer", "url":"https://issuer.trustbloc.local/didcomm", "oidcProvider":"https://hydra.trustbloc.local/", "scopes":["mDL"], "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/driver-license-evidence-v1.jsonld"], "supportsAssuranceCredential" : true, "requiresBlindedRoute": true}' \
    --insecure https://issuer.adapter.rest.example.com:10061/profile | jq -r '.createdAt' 2>/dev/null)
    echo "'created' field from profile tb-dl-issuer response is: $responseCreatedTime"
 

--- a/test/bdd/fixtures/scripts/hydra/hydra_configure.sh
+++ b/test/bdd/fixtures/scripts/hydra/hydra_configure.sh
@@ -11,6 +11,7 @@ echo "Create client"
 hydra clients create \
     --endpoint https://hydra.trustbloc.local:4445 \
     --id auth-code-client \
+    --name Share\ Your\ Credentials \
     --secret secret \
     --grant-types authorization_code,refresh_token \
     --response-types code,id_token \


### PR DESCRIPTION
- Issuer adapter requests login&consent for an access/refresh token that is scoped for a particular credential.
- Issuer adapter sends this token in an Authorization header with every   request for credential/assurance data.
- Issuer does not request login&consent, as the user ID, credential scope  information, and proof of consent are all determined by introspecting  the token sent by the issuer adapter.
- Issuer does not pre-fetch data from the CMS and cache it, instead performing the CMS lookup to service issuer-adapter requests as they come in.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>