### PR TITLE
chore: update wallet-support

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -15,8 +15,8 @@ CONSENT_LOGIN_SERVER_IMAGE=ghcr.io/trustbloc/sandbox-login-consent-server
 # Edge agent
 USER_AGENT_IMAGE=ghcr.io/trustbloc/wallet-web
 USER_AGENT_IMAGE_TAG=0.1.6
-USER_AGENT_SUPPORT_IMAGE=ghcr.io/trustbloc/wallet-server
-USER_AGENT_SUPPORT_IMAGE_tag=0.1.6
+USER_AGENT_SUPPORT_IMAGE=ghcr.io/trustbloc-cicd/wallet-server
+USER_AGENT_SUPPORT_IMAGE_tag=0.1.7-snapshot-720e8fa
 WALLET_ROUTER_URL=https://router.trustbloc.local:9084
 SUPPORT_BLINDED_ROUTING=true
 

--- a/test/bdd/fixtures/demo/docker-compose-wallet.yml
+++ b/test/bdd/fixtures/demo/docker-compose-wallet.yml
@@ -71,6 +71,8 @@ services:
       - ARIESD_DATABASE_PREFIX=edgeagent_usragdb
       - ARIESD_DATABASE_TIMEOUT=60
       - ARIESD_DATABASE_URL=edgeagent:edgeagent-secret-pw@tcp(mysql:3306)/
+      # 3600 secs = 60 mins
+      - HTTP_SERVER_COOKIE_MAXAGE=3600
     ports:
       - 8092:8092
     volumes:


### PR DESCRIPTION
wallet-support: make session cookie max age configurable: trustbloc/edge-agent#685

Signed-off-by: George Aristy <george.aristy@securekey.com>