### PR TITLE
fix: DIDAuth pages rendering issue in safari 

### DIFF
--- a/cmd/issuer-rest/static/didAuth.html
+++ b/cmd/issuer-rest/static/didAuth.html
@@ -95,7 +95,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <div class="flex flex-col sm:flex-row justify-center pt-12 my-12 sm:my-4 ">
             <div class="flex flex-col w-5/6 lg:w-1/2 mx-auto lg:mx-0 rounded-lg bg-white mt-4 sm:-mt-6 shadow-lg z-10">
-                <div class="flex-1 bg-white rounded-t rounded-b-none overflow-hidden shadow" >
+                <div class="flex-1 bg-white rounded-t rounded-b-none shadow" >
                     <div>
 
                         <h3 class="w-full p-4 text-2xl font-bold text-center" id="title-board">Let's Begin User Wallet Authentication</h3>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-03-11 at 9 01 05 PM" src="https://user-images.githubusercontent.com/7862595/110880779-26646980-82ad-11eb-980c-fab531cde959.png">
