### PR TITLE
chore: remove did:key from universal-resolver

### DIFF
--- a/test/bdd/fixtures/universal-resolver/config.json
+++ b/test/bdd/fixtures/universal-resolver/config.json
@@ -29,11 +29,6 @@
       "image": "uport/uni-resolver-driver-did-uport",
       "imagePort": "8081",
       "tag": "latest"
-    },
-    {
-      "pattern": "^(did:key:.+)$",
-      "image": "universalresolver/driver-did-key",
-      "tag": "latest"
     }
   ]
 }


### PR DESCRIPTION
- We are using aries did key implementation

Signed-off-by: Firas Qutishat <firas.qutishat@securekey.com>