### PR TITLE
feat: Issuer - Auth API

### DIFF
--- a/pkg/restapi/issuer/controller_test.go
+++ b/pkg/restapi/issuer/controller_test.go
@@ -39,5 +39,5 @@ func TestController_GetOperations(t *testing.T) {
 	require.NotNil(t, controller)
 
 	ops := controller.GetOperations()
-	require.Equal(t, 16, len(ops))
+	require.Equal(t, 17, len(ops))
 }


### PR DESCRIPTION
- Redirects user to oauth provider
- Returns the control to the callbackURL passed in the request after auth

closes #946 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>