### PR TITLE
chore: Support to undeploy and deploy components without restarting minikube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
   Publish:
     needs: [Checks, UnitTest]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.repository == 'trustbloc/sandbox' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DID_ELEMENT_SIDETREE_REQUEST_URL ?= https://element-did.com/api/v1/sidetree/requ
 SANDBOX_CLI_IMAGE_NAME       ?= trustbloc/sandbox-cli
 
 # TrustBloc core k8s deployment scripts https://github.com/trustbloc/k8s
-TRUSTBLOC_CORE_K8S_COMMIT=63272bba9d53516ec4be892fe9962c7168109d63
+TRUSTBLOC_CORE_K8S_COMMIT=c978b5759bdb90f8c68a125616f635b26eae82a4
 
 # Tool commands (overridable)
 ALPINE_VER ?= 3.12
@@ -140,6 +140,10 @@ setup-deploy: clean
 .PHONY: ci-setup-deploy
 ci-setup-deploy: clean
 	@TRUSTBLOC_CORE_K8S_COMMIT=$(TRUSTBLOC_CORE_K8S_COMMIT) make ci-setup-deploy -C ./k8s
+
+.PHONY: undeploy-all
+undeploy-all:
+	@make undeploy-all -C ./k8s
 
 .PHONY: deploy-all
 deploy-all:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ by the [TrustBloc](https://github.com/trustbloc) projects.
 - [TrustBloc Anonymous Comparator and Extractor(ACE)](docs/components/ace_components.md)
 
 ## Build and Deployment
-For pre-requisites, please refer [TrustBloc k8s deployments](https://github.com/trustbloc/k8s/blob/main/README.md).
+For pre-requisites, please refer [TrustBloc k8s deployments](https://github.com/trustbloc/k8s/blob/main/README.md). 
+
+The sandbox k8s is dependent on [TrustBloc k8s](https://github.com/trustbloc/k8s). Use TRUSTBLOC_CORE_K8S_COMMIT 
+variable in [Makefile](Makefile) point to the TrustBloc k8s deployment version. Alternatively, uncomment the 
+[symlink command](./k8s/scripts/core_deployment.sh) to point it to the cloned TrustBloc k8s repo.
 
 Run following target to run the components locally.
 ```
@@ -48,6 +52,12 @@ make setup-deploy
 
 # stops the k8s cluster
 make minikube-down
+
+# undeploys all the components without bringing down minikube
+make undeploy-all
+
+# deploys all the components provided minikube is up
+make deploy-all
 ```
 
 The SSL CA cert located inside `~/.trustbloc-k8s/local/certs/` need to be imported to system cert chain.

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -17,6 +17,11 @@ CLI_IMG_LOCAL         	 		?= ghcr.io/trustbloc/sandbox-cli:${CURRENT_TIME}
 
 .PHONY: deploy-all deploy-components setup-deploy ci-deploy-all ci-deploy-core ci-setup-deploy ci-minikube-setup local-setup-deploy minikube-up minikube-down minikube-image-load
 
+undeploy-all:
+	# TODO instead of delete all, run undeploy target on each component
+	@kubectl delete all --all -n default
+	echo "removed all components"
+
 deploy-all: deploy-core
 	./scripts/deploy_all.sh
 

--- a/k8s/scripts/core_deployment.sh
+++ b/k8s/scripts/core_deployment.sh
@@ -17,6 +17,9 @@ cd $core_dir
 git clone -b main https://github.com/trustbloc/k8s $core_dir
 git checkout ${TRUSTBLOC_CORE_K8S_COMMIT}
 
+# uncomment below line to link deployments to https://github.com/trustbloc/k8s directly (assuming k8s repo is in same folder as sandbox)
+# rm -rf $core_dir && mkdir -p $core_dir && ln -s ../../../k8s/* $core_dir
+
 cd $root
 
 echo "pull trustbloc core deployment configs - end"


### PR DESCRIPTION
- update k8s dep version
- add condition to run publish job only in source repo
- update readme with new targets

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>