### PR TITLE
feat: Add MongoDB instance for demo components

### DIFF
--- a/k8s/ace-rp/Makefile
+++ b/k8s/ace-rp/Makefile
@@ -14,7 +14,7 @@ export DEPLOYMENT_ENV	?= local
 # space delimited of Key:Value pairs
 COMMON_LABELS		:= instance:${DEPLOYMENT_ENV}
 export DOMAIN      		?= ${DEPLOYMENT_ENV}.trustbloc.dev
-export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb:27017
+export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb-demo:27017
 
 OS 				= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH  				= $(shell uname -m | sed 's/x86_64/amd64/')

--- a/k8s/ace-rp/kustomize/ace-rp/overlays/common/benefits-dept/secret.env
+++ b/k8s/ace-rp/kustomize/ace-rp/overlays/common/benefits-dept/secret.env
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0 
 # 
 
-DATABASE_UR=||MONGODB_URL||
+DATABASE_URL=||MONGODB_URL||
 ACE_REQUEST_TOKENS=vcs_issuer=vcs_issuer_rw_token

--- a/k8s/ace-rp/kustomize/ace-rp/overlays/common/cbp/secret.env
+++ b/k8s/ace-rp/kustomize/ace-rp/overlays/common/cbp/secret.env
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0 
 # 
 
-DATABASE_UR=||MONGODB_URL||
+DATABASE_URL=||MONGODB_URL||
 ACE_REQUEST_TOKENS=vcs_issuer=vcs_issuer_rw_token

--- a/k8s/ace-rp/kustomize/ace-rp/overlays/common/ucis/secret.env
+++ b/k8s/ace-rp/kustomize/ace-rp/overlays/common/ucis/secret.env
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0 
 # 
 
-DATABASE_UR=||MONGODB_URL||
+DATABASE_URL=||MONGODB_URL||
 ACE_REQUEST_TOKENS=vcs_issuer=vcs_issuer_rw_token

--- a/k8s/comparator/Makefile
+++ b/k8s/comparator/Makefile
@@ -15,7 +15,7 @@ export DEPLOYMENT_ENV	?= local
 COMMON_LABELS		:= instance:${DEPLOYMENT_ENV}
 export DOMAIN      		?= ${DEPLOYMENT_ENV}.trustbloc.dev
 export BLOC_DOMAIN		?= orb-1.${DOMAIN}
-export MONGODB_DSN								?= mongodb://mongoroot:secret@mongodb:27017
+export MONGODB_DSN								?= mongodb://mongoroot:secret@mongodb-demo:27017
 export COMPARATOR_REQUEST_TOKENS ?= sidetreeToken=ADMIN_TOKEN
 
 OS 				= $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/k8s/comparator/README.md
+++ b/k8s/comparator/README.md
@@ -22,7 +22,7 @@
 	- `cbp-comparator.DOMAIN`
 	- `ucis-comparator.DOMAIN`
 * Will deploy Sandbox Comparator, pointing to an already provisioned MongoDB specified with `MONGODB_DSN`
-	- `make deploy MONGODB_DSN=mongodb://mongoroot:secret@mongodb:27017`
+	- `make deploy MONGODB_DSN=mongodb://mongoroot:secret@mongodb-demo:27017`
 * if running `podman` pass `CONTAINER_CMD=podman` as option to make
 * Running with none self-signed certificates: place certs into kustomize/comparator/overlays/sandbox/certs, then run with: `make setup-no-certs`.
 >files:

--- a/k8s/demo-dbs/Makefile
+++ b/k8s/demo-dbs/Makefile
@@ -19,6 +19,7 @@ ARCH  				= $(shell uname -m | sed 's/x86_64/amd64/')
 
 #IMAGES
 MYSQL_IMG		?= docker.io/mysql:8.0.20
+MONGODB_IMG		?= docker.io/mongo:4.0
 # do not modify
 KUSTOMIZE_DIR       	= kustomize/demo-dbs
 PREFIX							?=
@@ -46,6 +47,9 @@ set-labels: kustomize
 
 .PHONY: set-images
 set-images: kustomize
+	@pushd ${KUSTOMIZE_DIR}/components/mongodb &&\
+	${KUSTOMIZE} edit set image mongo=${MONGODB_IMG} &&\
+	popd &&\
 	pushd ${KUSTOMIZE_DIR}/components/mysql &&\
 	${KUSTOMIZE} edit set image mysql=${MYSQL_IMG} &&\
 	popd

--- a/k8s/demo-dbs/README.md
+++ b/k8s/demo-dbs/README.md
@@ -14,4 +14,4 @@
 * `make clean`
 
 ## options and features
-* Will deploy Sandbox MySQL.
+* Will deploy Sandbox MongoDB and MySQL.

--- a/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/deployment.yml
+++ b/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/deployment.yml
@@ -1,0 +1,42 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: mongodb-demo
+  name: mongodb-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb-demo
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: mongodb-demo
+    spec:
+      hostname: mongodb-demo
+      containers:
+      - image: mongo:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+          - name: mongodb-port
+            protocol: TCP
+            containerPort: 27017
+        name: mongodb
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          value: 'mongoroot'
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          value: 'secret'
+        resources: {}
+status: {}

--- a/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/kustomization.yaml
+++ b/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/kustomization.yaml
@@ -1,0 +1,16 @@
+# 
+# Copyright SecureKey Technologies Inc. All Rights Reserved. 
+# 
+# SPDX-License-Identifier: Apache-2.0 
+# 
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+images:
+- name: mongo
+  newName: docker.io/mongo
+  newTag: "4.0"
+
+resources:
+- deployment.yml
+- service.yml

--- a/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/service.yml
+++ b/k8s/demo-dbs/kustomize/demo-dbs/components/mongodb/service.yml
@@ -1,0 +1,22 @@
+# 
+# Copyright SecureKey Technologies Inc. All Rights Reserved. 
+# 
+# SPDX-License-Identifier: Apache-2.0 
+# 
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: mongodb-demo
+spec:
+  ports:
+  - name: mongodb-port
+    port: 27017
+    protocol: TCP
+    targetPort: mongodb-port
+  selector:
+    app: mongodb-demo
+status:
+  loadBalancer: {}

--- a/k8s/demo-dbs/kustomize/demo-dbs/overlays/common/kustomization.yaml
+++ b/k8s/demo-dbs/kustomize/demo-dbs/overlays/common/kustomization.yaml
@@ -22,4 +22,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
+- ../../components/mongodb
 - ../../components/mysql

--- a/k8s/issuer/Makefile
+++ b/k8s/issuer/Makefile
@@ -14,7 +14,7 @@ export DEPLOYMENT_ENV	?= local
 # space delimited of Key:Value pairs
 COMMON_LABELS		:= instance:${DEPLOYMENT_ENV}
 export DOMAIN      		?= ${DEPLOYMENT_ENV}.trustbloc.dev
-export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb:27017
+export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb-demo:27017
 
 OS 				= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH  				= $(shell uname -m | sed 's/x86_64/amd64/')

--- a/k8s/issuer/README.md
+++ b/k8s/issuer/README.md
@@ -19,7 +19,7 @@
 * Will create an Ingress for external access. When running with unregistered dns domains, create records (/etc/hosts) for:
 	- `issuer.DOMAIN`
 * Will deploy Sandbox Demo Applications, pointing to an already provisioned MongoDB specified with `MONGODB_URL`
-	- `make deploy MONGODB_URL=mongodb://mongoroot:secret@mongodb:27017`
+	- `make deploy MONGODB_URL=mongodb://mongoroot:secret@mongodb-demo:27017`
 * if running `podman` pass `CONTAINER_CMD=podman` as option to make
 * Running with none self-signed certificates: place certs into kustomize/demo-applications/overlays/sandbox/certs, then run with: `make setup-no-certs`.
 >files:

--- a/k8s/rp/Makefile
+++ b/k8s/rp/Makefile
@@ -14,7 +14,7 @@ export DEPLOYMENT_ENV	?= local
 # space delimited of Key:Value pairs
 COMMON_LABELS		:= instance:${DEPLOYMENT_ENV}
 export DOMAIN      		?= ${DEPLOYMENT_ENV}.trustbloc.dev
-export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb:27017
+export MONGODB_URL								?= mongodb://mongoroot:secret@mongodb-demo:27017
 
 OS 				= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH  				= $(shell uname -m | sed 's/x86_64/amd64/')

--- a/k8s/rp/README.md
+++ b/k8s/rp/README.md
@@ -19,7 +19,7 @@
 * Will create an Ingress for external access. When running with unregistered dns domains, create records (/etc/hosts) for:
 	- `rp.DOMAIN`
 * Will deploy Sandbox Demo Applications, pointing to an already provisioned MongoDB specified with `MONGODB_URL`
-	- `make deploy MONGODB_URL=mongodb://mongoroot:secret@mongodb:27017`
+	- `make deploy MONGODB_URL=mongodb://mongoroot:secret@mongodb-demo:27017`
 * if running `podman` pass `CONTAINER_CMD=podman` as option to make
 * Running with none self-signed certificates: place certs into kustomize/demo-applications/overlays/sandbox/certs, then run with: `make setup-no-certs`.
 >files:


### PR DESCRIPTION
- Added a MongoDB instance for demo components, similar to the couchdb-demo instance that used to exist.
- Also fixed some environment variables with incorrect names (DATABASE_UR instead of DATABASE_URL).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>