### PR TITLE
test: use button name instead of id for sign-up provider

### DIFF
--- a/test/ui-automation/test/helpers/wallet.js
+++ b/test/ui-automation/test/helpers/wallet.js
@@ -101,7 +101,7 @@ async function _sendCredentials({method = "trustbloc"} = {}) {
 }
 
 async function _getSignUp(email) {
-    const signUpButton = await $('#signUpText');
+    const signUpButton = await $('button*=Demo Sign-Up Partner');
     await signUpButton.waitForExist();
     await signUpButton.click();
     await _getThirdPartyLogin(email);


### PR DESCRIPTION
closes #1322 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>